### PR TITLE
June upstream merge: Fix yaml linter errors

### DIFF
--- a/Resources/Prototypes/Actions/revenant.yml
+++ b/Resources/Prototypes/Actions/revenant.yml
@@ -18,6 +18,7 @@
   - type: Action
     useDelay: 15
     icon: Interface/Actions/defile.png
+    itemIconStyle: NoItem #imp edit
   - type: InstantAction
     event: !type:RevenantDefileActionEvent
 
@@ -30,6 +31,7 @@
   - type: Action
     icon: Interface/Actions/overloadlight.png
     useDelay: 20
+    itemIconStyle: NoItem #imp edit
   - type: InstantAction
     event: !type:RevenantOverloadLightsActionEvent
 
@@ -53,6 +55,7 @@
   components:
   - type: Action
     icon: Interface/Actions/malfunction.png
+    itemIconStyle: NoItem #imp edit
     useDelay: 20
   - type: InstantAction
     event: !type:RevenantMalfunctionActionEvent

--- a/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
@@ -4,17 +4,7 @@
     sprite: Objects/Consumable/Food/Baked/pizza.rsi
     state: margherita-slice
   product: CrateFoodPizza
-  cost: 550 # IMP 450 > 550
-  category: cargoproduct-category-name-food
-  group: market
-
-- type: cargoProduct
-  id: FoodPizzaLarge
-  icon:
-    sprite: Objects/Consumable/Food/Baked/pizza.rsi
-    state: margherita
-  product: CrateFoodPizzaLarge
-  cost: 1800
+  cost: 1600
   category: cargoproduct-category-name-food
   group: market
 

--- a/Resources/Prototypes/Entities/Clothing/Neck/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/misc.yml
@@ -1,3 +1,4 @@
+#TODO this should be able to be changed to upstream implementation with toggleablevisuals being fixed
 - type: entity
   parent: ClothingNeckPullableBase # imp
   id: ClothingNeckHeadphones

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -204,15 +204,16 @@
 
 # Begin CD - Character Records
 - type: entity
+  parent: BaseAction
   id: ActionAGhostShowCharacterRecords
   name: Character Records Interface
   description: View all of the character records
-  categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
+  - type: Action
     icon: { sprite: Interface/Actions/actions_ai.rsi, state: station_records } #imp edit - use a real sprite for this since it's going on the AI as well.
     iconOn: Interface/Actions/actions_ai.rsi/station_records.png
     keywords: [ "AI", "console", "interface" ]
     priority: -10
+  - type: InstantAction
     event: !type:ToggleIntrinsicUIEvent { key: enum.CharacterRecordConsoleKey.Key }
 # Edn CD - Character Records

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -91,20 +91,22 @@
     followEntity: true
   - type: IgnoreUIRange # imp. pretty much all this does is make it so that ghosts can see IDs and health info at any range, since ghosts don't have hands or complexinteract
 
-# imp - ActionAghostShowRadar except with CheckCanInteract set to false, and a UseDelay
+# imp - ActionAghostShowRadar except with BaseMentalAction parent and a UseDelay
 - type: entity
+  parent: BaseMentalAction
   id: ActionGhostShowRadar
   name: Mass Scanner Interface
   description: View a Mass Scanner Interface.
   components:
-  - type: InstantAction
+  - type: Action
     checkCanInteract: false
     icon: { sprite: Interface/Actions/actions_ai.rsi, state: mass_scanner }
     iconOn: Interface/Actions/actions_ai.rsi/mass_scanner.png
     keywords: [ "AI", "console", "interface" ]
     priority: -6
-    event: !type:ToggleIntrinsicUIEvent { key: enum.RadarConsoleUiKey.Key }
     useDelay: 60 # to discourage everyone from opening it at once and causing potential perf issues.
+  - type: InstantAction
+    event: !type:ToggleIntrinsicUIEvent { key: enum.RadarConsoleUiKey.Key }
 
 - type: entity
   parent: BaseMentalAction

--- a/Resources/Prototypes/Entities/Objects/Magic/books.yml
+++ b/Resources/Prototypes/Entities/Objects/Magic/books.yml
@@ -185,30 +185,6 @@
         ActionFireball: -1
 
 - type: entity
-  id: SpawnSpaceGreaseSpellbook
-  name: space grease spellbook
-  parent: BaseSpellbook
-  components:
-    - type: Sprite
-      sprite: Objects/Misc/books.rsi
-      layers:
-      - state: paper
-      - state: cover_old
-        color: "#ba5a14"
-      - state: decor_wingette_circle
-        color: gold
-      - state: detail_rivets
-        color: gold
-      - state: detail_bookmark
-        color: "#e89b3c"
-      - state: overlay_dirt
-      - state: icon_magic_grease
-        shader: unshaded
-    - type: Spellbook
-      spellActions:
-        ActionSpawnSpaceGreaseSpell: -1
-
-- type: entity
   id: ScrollRunes
   name: scroll of runes
   parent: BaseSpellbook

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -738,33 +738,3 @@
       amount: 1
   products:
     Haloperidol: 5
-
-- type: reaction
-  id: Traumoxadone
-  impact: Medium
-  reactants:
-    Cryoxadone:
-      amount: 1
-    Bicaridine:
-      amount: 1
-    Fersilicite:
-      amount: 1
-    Lipozine:
-      amount: 1
-  products:
-    Traumoxadone: 3
-
-- type: reaction
-  id: Stelloxadone
-  impact: Medium
-  reactants:
-    Stellibinin:
-      amount: 5
-    Cryoxadone:
-      amount: 3
-    Arithrazine:
-      amount: 2
-  products:
-    Stelloxadone: 5
-    Water: 3
-    Fiber: 2

--- a/Resources/Prototypes/_DV/Actions/borgs.yml
+++ b/Resources/Prototypes/_DV/Actions/borgs.yml
@@ -1,11 +1,13 @@
 - type: entity
+  parent: BaseAction
   id: ActionFabricateGumball
   name: Fabricate Gumball
   description: Fabricate a gumball full of sugar and medicine to treat small injuries.
   components:
-  - type: InstantAction
+  - type: Action
     icon: { sprite: _DV/Objects/Consumable/Food/candy.rsi, state: gumball }
     iconColor: '#FFAED7'
     useDelay: 40
+  - type: InstantAction
     event: !type:FabricateCandyActionEvent
       item: FoodGumball

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/harpy.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/harpy.yml
@@ -1,20 +1,24 @@
 - type: entity
+  parent: BaseAction
   id: ActionHarpyPlayMidi
   name: Play MIDI
   description: Sing your heart out! Right click yourself to set an instrument.
   components:
-  - type: InstantAction
+  - type: Action
     checkCanInteract: false
     icon: _DV/Interface/Actions/harpy_sing.png
+  - type: InstantAction
     event: !type:OpenUiActionEvent
       key: enum.InstrumentUiKey.Key
 
 - type: entity
+  parent: BaseAction
   id: ActionSyrinxChangeVoiceMask
   name: Set name
   description: Change the name others hear to something else.
   components:
-  - type: InstantAction
+  - type: Action
     icon: _DV/Interface/Actions/harpy_syrinx.png
     itemIconStyle: BigAction
+  - type: InstantAction
     event: !type:VoiceMaskSetNameEvent

--- a/Resources/Prototypes/_EE/Actions/types.yml
+++ b/Resources/Prototypes/_EE/Actions/types.yml
@@ -1,29 +1,31 @@
 - type: entity
+  parent: BaseAction
   id: ToggleNightVision
   name: Switch night vision
   description: Switches night vision.
-  categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
+  - type: Action
     itemIconStyle: BigAction
     priority: -20
     icon:
       sprite: _EE/Clothing/Eyes/Goggles/nightvision.rsi
       state: icon
+  - type: InstantAction
     event: !type:ToggleNightVisionEvent
 
 - type: entity
+  parent: BaseAction
   id: ToggleThermalVision
   name: Switch Thermal vision
   description: Switches Thermal vision.
-  categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
+  - type: Action
     itemIconStyle: BigAction
     priority: -20
     icon:
       sprite: _EE/Clothing/Eyes/Goggles/thermal.rsi
       state: icon
+  - type: InstantAction
     event: !type:ToggleThermalVisionEvent
 
 - type: entity
@@ -31,8 +33,7 @@
   parent: ToggleThermalVision
   name: Pulse Thermal Vision
   description: Activate thermal vision temporarily.
-  categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
+  - type: Action
     useDelay: 4
 

--- a/Resources/Prototypes/_Goobstation/Changeling/Actions/changeling.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Actions/changeling.yml
@@ -1,16 +1,17 @@
 # Starting
 
 - type: entity
+  parent: BaseAction
   id: ActionEvolutionMenu
   name: Open Evolution Menu
   description: Opens the evolution menu.
-  categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
+  - type: Action
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Changeling/changeling_abilities.rsi
       state: evolution_menu
+  - type: InstantAction
     event: !type:OpenEvolutionMenuEvent {}
   - type: ChangelingAction
     requireBiomass: false
@@ -18,22 +19,23 @@
     useInLastResort: true
 
 - type: entity
+  parent: BaseAction
   id: ActionAbsorbDNA
   name: Absorb DNA
   description: Absorbs the DNA of our incapacitated victim. Costs a small amount of chemicals.
-  categories: [ HideSpawnMenu ]
   components:
-  - type: EntityTargetAction
-    useDelay: 5
-    whitelist:
-      components:
-      - Body
-    canTargetSelf: false
-    interactOnMiss: false
+  - type: Action
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Changeling/changeling_abilities.rsi
       state: absorb_dna
+    useDelay: 5
+  - type: TargetAction
+  - type: EntityTargetAction
+    whitelist:
+      components:
+      - Body
+    canTargetSelf: false
     event: !type:AbsorbDNAEvent {}
   - type: ChangelingAction
     chemicalCost: 25
@@ -41,72 +43,74 @@
     useInLesserForm: true
 
 - type: entity
+  parent: BaseAction
   id: ActionStingExtractDNA
   name: Extract DNA Sting
   description: We stealthily sting a target and extract their DNA. Costs a small amount of chemicals.
-  categories: [ HideSpawnMenu ]
   components:
+  - type: Action
+    itemIconStyle: NoItem
+    icon:
+      sprite: _Goobstation/Changeling/changeling_abilities.rsi
+      state: sting_extractdna
+  - type: TargetAction
   - type: EntityTargetAction
     whitelist:
       components:
       - Body
     canTargetSelf: false
-    interactOnMiss: false
-    itemIconStyle: NoItem
-    icon:
-      sprite: _Goobstation/Changeling/changeling_abilities.rsi
-      state: sting_extractdna
     event: !type:StingExtractDNAEvent {}
   - type: ChangelingAction
     chemicalCost: 25
     useInLesserForm: true
 
 - type: entity
+  parent: BaseAction
   id: ActionChangelingTransformCycle
   name: Cycle DNA
   description: Cycle our available DNA.
-  categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
+  - type: Action
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Changeling/changeling_abilities.rsi
       state: transform_cycle
+  - type: InstantAction
     event: !type:ChangelingTransformCycleEvent {}
   - type: ChangelingAction
     requireBiomass: false
     useInLesserForm: true
 
 - type: entity
+  parent: BaseAction
   id: ActionChangelingTransform
   name: Transform
   description: We take on the voice and appearance of one we have absorbed. Costs a trace amount of chemicals.
-  categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
+  - type: Action
     useDelay: 5
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Changeling/changeling_abilities.rsi
       state: transform
+  - type: InstantAction
     event: !type:ChangelingTransformEvent {}
   - type: ChangelingAction
     chemicalCost: 5
     useInLesserForm: true
 
 - type: entity
+  parent: BaseMentalAction
   id: ActionEnterStasis
   name: Enter Regenerative Stasis
   description: We fall into a stasis, allowing us to regenerate while appearing dead to the unwise. Drains all of our chemicals, and consumes biomass.
-  categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
-    checkCanInteract: false
-    checkConsciousness: false
+  - type: Action
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Changeling/changeling_abilities.rsi
       state: stasis_enter
+  - type: InstantAction
     event: !type:EnterStasisEvent {}
   - type: ChangelingAction
     biomassCost: 1
@@ -114,18 +118,17 @@
     useInLastResort: true
 
 - type: entity
+  parent: BaseMentalAction
   id: ActionExitStasis
   name: Exit Stasis
   description: We arise once more. Costs a large amount of chemicals.
-  categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
-    checkCanInteract: false
-    checkConsciousness: false
+  - type: Action
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Changeling/changeling_abilities.rsi
       state: stasis_exit
+  - type: InstantAction
     event: !type:ExitStasisEvent {}
   - type: ChangelingAction
     chemicalCost: 60
@@ -135,10 +138,10 @@
 # Combat
 
 - type: entity
+  parent: BaseAction
   id: ActionToggleArmblade
   name: Toggle Arm Blade
   description: We shape one of our arms into a strong blade. We may retract our blade in the same manner as we form it. Costs a small amount of chemicals.
-  categories: [ HideSpawnMenu ]
   components:
   - type: Action
     useDelay: 2
@@ -152,67 +155,71 @@
     chemicalCost: 15
 
 - type: entity
+  parent: BaseAction
   id: ActionCreateBoneShard
   name: Form Bone Shard
   description: We break off shards of sharp bone to use as projectiles. Costs a small amount of chemicals.
-  categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
+  - type: Action
     useDelay: 1
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Changeling/changeling_abilities.rsi
       state: bone_shard
+  - type: InstantAction
     event: !type:CreateBoneShardEvent {}
   - type: ChangelingAction
     chemicalCost: 15
 
 - type: entity
+  parent: BaseAction
   id: ActionToggleChitinousArmor
   name: Toggle Chitin
   description: We turn our skin into tough chitin to protect us from damage. Costs a small amount of chemicals.
-  categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
+  - type: Action
     useDelay: 2
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Changeling/changeling_abilities.rsi
       state: chitinous_armor
+  - type: InstantAction
     event: !type:ToggleChitinousArmorEvent {}
   - type: ChangelingAction
     chemicalCost: 25
     requireAbsorbed: 2
 
 - type: entity
+  parent: BaseAction
   id: ActionToggleOrganicShield
   name: Form Shield
   description: We reform one of our arms into a hard, yet brittle shield. Costs a small amount of chemicals.
-  categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
+  - type: Action
     useDelay: 2
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Changeling/changeling_abilities.rsi
       state: organic_shield
+  - type: InstantAction
     event: !type:ToggleOrganicShieldEvent {}
   - type: ChangelingAction
     chemicalCost: 20
     requireAbsorbed: 1
 
 - type: entity
+  parent: BaseAction
   id: ActionShriekDissonant
   name: Dissonant Shriek
   description: We shift our vocal cords to release a high-frequency sound that overloads nearby electronics. Costs a small amount of chemicals.
-  categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
+  - type: Action
     useDelay: 10
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Changeling/changeling_abilities.rsi
       state: shriek_dissonant
+  - type: InstantAction
     event: !type:ShriekDissonantEvent {}
   - type: ChangelingAction
     chemicalCost: 30
@@ -220,17 +227,18 @@
     requireAbsorbed: 1
 
 - type: entity
+  parent: BaseAction
   id: ActionShriekResonant
   name: Resonant Shriek
   description: We emit a high-frequency sound that confuses and deafens organics, blows out nearby lights, and overloads cyborg sensors. Costs a small amount of chemicals.
-  categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
+  - type: Action
     useDelay: 10
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Changeling/changeling_abilities.rsi
       state: shriek_resonant
+  - type: InstantAction
     event: !type:ShriekResonantEvent {}
   - type: ChangelingAction
     chemicalCost: 30
@@ -238,17 +246,18 @@
     requireAbsorbed: 1
 
 - type: entity
+  parent: BaseAction
   id: ActionToggleStrainedMuscles
   name: Strain Muscles
   description: We move at extremely fast speeds. Rapidly fatigues us.
-  categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
+  - type: Action
     useDelay: 1
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Changeling/changeling_abilities.rsi
       state: strained_muscles
+  - type: InstantAction
     event: !type:ToggleStrainedMusclesEvent {}
   - type: ChangelingAction
     chemicalCost: 0
@@ -257,147 +266,154 @@
 # Stings
 
 - type: entity
+  parent: BaseAction
   id: ActionStingBlind
   name: Blind Sting
   description: We sting a target, blinding them temporarily. Costs a sizeable amount of chemicals. Stinging multiple times won't intensify the effect.
-  categories: [ HideSpawnMenu ]
   components:
+  - type: Action
+    itemIconStyle: NoItem
+    icon:
+      sprite: _Goobstation/Changeling/changeling_abilities.rsi
+      state: sting_blind
+  - type: TargetAction
   - type: EntityTargetAction
     whitelist:
       components:
       - Body
     canTargetSelf: false
-    interactOnMiss: false
-    itemIconStyle: NoItem
-    icon:
-      sprite: _Goobstation/Changeling/changeling_abilities.rsi
-      state: sting_blind
     event: !type:StingBlindEvent {}
   - type: ChangelingAction
     chemicalCost: 50
     useInLesserForm: true
 
 - type: entity
+  parent: BaseAction
   id: ActionStingCryo
   name: Cryogenic Sting
   description: We inject a target with a cocktail of chemicals that chills the blood. Costs a medium amount of chemicals.
-  categories: [ HideSpawnMenu ]
   components:
+  - type: Action
+    itemIconStyle: NoItem
+    icon:
+      sprite: _Goobstation/Changeling/changeling_abilities.rsi
+      state: sting_cryo
+  - type: TargetAction
   - type: EntityTargetAction
     whitelist:
       components:
       - Body
     canTargetSelf: false
-    interactOnMiss: false
-    itemIconStyle: NoItem
-    icon:
-      sprite: _Goobstation/Changeling/changeling_abilities.rsi
-      state: sting_cryo
     event: !type:StingCryoEvent {}
   - type: ChangelingAction
     chemicalCost: 35
     useInLesserForm: true
 
 - type: entity
+  parent: BaseAction
   id: ActionStingLethargic
   name: Lethargic Sting
   description: We inject a target with a cocktail of anesthetics, causing them to become slow and drowsy. Costs a medium amount of chemicals.
-  categories: [ HideSpawnMenu ]
   components:
+  - type: Action
+    itemIconStyle: NoItem
+    icon:
+      sprite: _Goobstation/Changeling/changeling_abilities.rsi
+      state: sting_lethargic
+  - type: TargetAction
   - type: EntityTargetAction
     whitelist:
       components:
       - Body
     canTargetSelf: false
-    interactOnMiss: false
-    itemIconStyle: NoItem
-    icon:
-      sprite: _Goobstation/Changeling/changeling_abilities.rsi
-      state: sting_lethargic
     event: !type:StingLethargicEvent {}
   - type: ChangelingAction
     chemicalCost: 35
     useInLesserForm: true
 
 - type: entity
+  parent: BaseAction
   id: ActionStingMute
   name: Mute Sting
   description: We sting a target, silencing them for a few minutes. Costs a medium amount of chemicals.
-  categories: [ HideSpawnMenu ]
   components:
+  - type: Action
+    itemIconStyle: NoItem
+    icon:
+      sprite: _Goobstation/Changeling/changeling_abilities.rsi
+      state: sting_mute
+  - type: TargetAction
   - type: EntityTargetAction
     whitelist:
       components:
       - Body
     canTargetSelf: false
-    interactOnMiss: false
-    itemIconStyle: NoItem
-    icon:
-      sprite: _Goobstation/Changeling/changeling_abilities.rsi
-      state: sting_mute
     event: !type:StingMuteEvent {}
   - type: ChangelingAction
     chemicalCost: 35
     useInLesserForm: true
 
 - type: entity
+  parent: BaseAction
   id: ActionStingFakeArmblade
   name: Fake Arm Blade Sting
   description: We sting a target, mutating their arm to temporarily appear as an arm blade. Costs a medium amount of chemicals.
-  categories: [ HideSpawnMenu ]
   components:
+  - type: Action
+    itemIconStyle: NoItem
+    icon:
+      sprite: _Goobstation/Changeling/changeling_abilities.rsi
+      state: sting_armblade
+  - type: TargetAction
   - type: EntityTargetAction
     whitelist:
       components:
       - Body
     canTargetSelf: false
-    interactOnMiss: false
-    itemIconStyle: NoItem
-    icon:
-      sprite: _Goobstation/Changeling/changeling_abilities.rsi
-      state: sting_armblade
     event: !type:StingFakeArmbladeEvent {}
   - type: ChangelingAction
     chemicalCost: 50
     useInLesserForm: true
 
 - type: entity
+  parent: BaseAction
   id: ActionStingTransform
   name: Transformation Sting
   description: We sting a target, injecting a retrovirus that causes them to transform. Costs a large amount of chemicals.
-  categories: [ HideSpawnMenu ]
   components:
+  - type: Action
+    itemIconStyle: NoItem
+    icon:
+      sprite: _Goobstation/Changeling/changeling_abilities.rsi
+      state: sting_transform
+  - type: TargetAction
   - type: EntityTargetAction
     whitelist:
       components:
       - Body
     canTargetSelf: false
-    interactOnMiss: false
-    itemIconStyle: NoItem
-    icon:
-      sprite: _Goobstation/Changeling/changeling_abilities.rsi
-      state: sting_transform
     event: !type:StingTransformEvent {}
   - type: ChangelingAction
     chemicalCost: 75
     useInLesserForm: true
 
 - type: entity
+  parent: BaseAction
   id: ActionLayEgg
   name: Lay Egg
   description: We plant an egg in a dead corpse which will mature into a new form for us.
-  categories: [ HideSpawnMenu ]
   components:
+  - type: Action
+    itemIconStyle: NoItem
+    icon:
+      sprite: _Goobstation/Changeling/changeling_abilities.rsi
+      state: lay_egg
+  - type: TargetAction
   - type: EntityTargetAction
     whitelist:
       components:
       - Body
     canTargetSelf: false
-    interactOnMiss: false
-    itemIconStyle: NoItem
-    icon:
-      sprite: _Goobstation/Changeling/changeling_abilities.rsi
-      state: lay_egg
     event: !type:StingLayEggsEvent {}
   - type: ChangelingAction
     chemicalCost: 0
@@ -406,125 +422,124 @@
 # Utility
 
 - type: entity
+  parent: BaseMentalAction
   id: ActionAnatomicPanacea
   name: Anatomic Panacea
   description: We expel impurities from our form, sobering us, and purging radiation and toxins. Costs a small amount of chemicals.
-  categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
+  - type: Action
     useDelay: 30
-    checkCanInteract: false
-    checkConsciousness: false
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Changeling/changeling_abilities.rsi
       state: anatomic_panacea
+  - type: InstantAction
     event: !type:ActionAnatomicPanaceaEvent {}
   - type: ChangelingAction
     chemicalCost: 30
     useInLesserForm: true
 
 - type: entity
+  parent: BaseAction
   id: ActionAugmentedEyesight
   name: Augmented Eyesight
   description: We grow a tinted nictitating membrane over our eyes, protecting our vision from sudden bright lights.
-  categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
+  - type: Action
     checkCanInteract: false
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Changeling/changeling_abilities.rsi
       state: augmented_eyesight
+  - type: InstantAction
     event: !type:ActionAugmentedEyesightEvent {}
   - type: ChangelingAction
     chemicalCost: 0
 
 - type: entity
+  parent: BaseAction
   id: ActionBiodegrade
   name: Biodegrade
   description: We spew a caustic substance, dissolving restraints and spraying those who hold onto us. Costs a small amount of chemicals.
-  categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
+  - type: Action
     useDelay: 5
     checkCanInteract: false
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Changeling/changeling_abilities.rsi
       state: biodegrade
+  - type: InstantAction
     event: !type:ActionBiodegradeEvent {}
   - type: ChangelingAction
     chemicalCost: 30
 
 - type: entity
+  parent: BaseMentalAction
   id: ActionChameleonSkin
   name: Chameleon Skin
   description: Our skin pigmentation rapidly changes to suit our current environment. Costs a small amount of chemicals.
-  categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
+  - type: Action
     useDelay: 1
-    checkCanInteract: false
-    checkConsciousness: false
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Changeling/changeling_abilities.rsi
       state: chameleon_skin
+  - type: InstantAction
     event: !type:ActionChameleonSkinEvent {}
   - type: ChangelingAction
     chemicalCost: 20
 
 - type: entity
+  parent: BaseMentalAction
   id: ActionEphedrineOverdose
   name: Ephedrine Overdose
   description: We inject a cocktail of stimulants into ourself. Costs a small amount of chemicals.
-  categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
+  - type: Action
     useDelay: 10
-    checkCanInteract: false
-    checkConsciousness: false
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Changeling/changeling_abilities.rsi
       state: epinephrine_overdose
+  - type: InstantAction
     event: !type:ActionEphedrineOverdoseEvent {}
   - type: ChangelingAction
     chemicalCost: 30
     useInLesserForm: true
 
 - type: entity
+  parent: BaseAction
   id: ActionFleshmend
   name: Fleshmend
   description: Our flesh rapidly regenerates, healing our burns, bruises, and asphyxiation. Costs a medium amount of chemicals.
-  categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
+  - type: Action
     useDelay: 30
     checkCanInteract: false
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Changeling/changeling_abilities.rsi
       state: fleshmend
+  - type: InstantAction
     event: !type:ActionFleshmendEvent {}
   - type: ChangelingAction
     chemicalCost: 35
     useInLesserForm: true
 
 - type: entity
+  parent: BaseMentalAction
   id: ActionHivemindAccess
   name: Hivemind Access
   description: We tune our chemical receptors for hivemind communication.
-  categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
-    checkCanInteract: false
-    checkConsciousness: false
+  - type: Action
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Changeling/changeling_abilities.rsi
       state: hivemind_access
+  - type: InstantAction
     event: !type:ActionHivemindAccessEvent {}
   - type: ChangelingAction
     chemicalCost: 0
@@ -535,16 +550,14 @@
   name: Last Resort
   parent: BaseSuicideAction
   description: We abandon our vessel, escaping in our vulnerable true self, to find a new body to occupy. Costs a small amount of chemicals.
-  categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
+  - type: Action
     useDelay: 5
-    checkCanInteract: false
-    checkConsciousness: false
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Changeling/changeling_abilities.rsi
       state: last_resort
+  - type: InstantAction
     event: !type:ActionLastResortEvent {}
   - type: ChangelingAction
     chemicalCost: 20
@@ -552,35 +565,37 @@
     useInLesserForm: true
 
 - type: entity
+  parent: BaseAction
   id: ActionToggleLesserForm
   name: Lesser Form
   description: We become lesser, transforming into a sentient monkey. Costs a small amount of chemicals.
-  categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
+  - type: Action
     useDelay: 5
     checkCanInteract: false
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Changeling/changeling_abilities.rsi
       state: lesser_form
+  - type: InstantAction
     event: !type:ActionLesserFormEvent {}
   - type: ChangelingAction
     chemicalCost: 20
 
 - type: entity
+  parent: BaseAction
   id: ActionToggleMindshieldFake
   name: Toggle Mindshield Patterns
   description: We shape our mental patterns to imitate a mindshield implantation.
-  categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
+  - type: Action
     useDelay: 1
     checkCanInteract: false
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Changeling/changeling_abilities.rsi
       state: mindshield
+  - type: InstantAction
     event: !type:ActionMindshieldFakeEvent {}
   - type: ChangelingAction
     chemicalCost: 0
@@ -588,17 +603,18 @@
 
     # imp edit ↓
 - type: entity
+  parent: BaseAction
   id: ActionToggleTentacle
   name: Toggle Tentacle
   description: We shape one of our arms into a Tendon Fishing rod. We may retract our Rod in the same manner as we form it. Costs a small amount of chemicals.
-  categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
+  - type: Action
     useDelay: 2
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Changeling/changeling_abilities.rsi
       state: tentacle
+  - type: InstantAction
     event: !type:ToggleTentacleEvent {}
   - type: ChangelingAction
     chemicalCost: 15
@@ -606,17 +622,18 @@
 #imp edit ^
 
 - type: entity
+  parent: BaseAction
   id: ActionToggleSpacesuit
   name: Toggle Space Adaptation
   description: We prepare our cells to resist barotrauma. Costs a small amount of chemicals.
-  categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
+  - type: Action
     useDelay: 2
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Changeling/changeling_abilities.rsi
       state: space_adaptation
+  - type: InstantAction
     event: !type:ActionSpacesuitEvent {}
   - type: ChangelingAction
     chemicalCost: 20

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Devices/Circuitboards/machine.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Devices/Circuitboards/machine.yml
@@ -32,6 +32,5 @@
   - type: MachineBoard
     prototype: StorageBin
     stackRequirements:
-      MatterBin: 2
-      Manipulator: 2
+      Manipulator: 4
       Steel: 1

--- a/Resources/Prototypes/_Goobstation/Heretic/Actions/Heretic/basic.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Actions/Heretic/basic.yml
@@ -1,47 +1,50 @@
 # actions
 - type: entity
+  parent: BaseAction
   id: ActionHereticOpenStore
   name: Open Knowledge Store
   description: Open the Knowledge Store.
-  categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
+  - type: Action
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Heretic/abilities_heretic.rsi
       state: open_store
+  - type: InstantAction
     event: !type:EventHereticOpenStore {}
   - type: HereticAction
     requireMagicItem: false
 
 - type: entity
+  parent: BaseAction
   id: ActionHereticMansusGrasp
   name: Mansus Grasp
   description: Channel the power of the Old Gods through your grip.
-  categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
+  - type: Action
     useDelay: 10
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Heretic/abilities_heretic.rsi
       state: mansus_grasp
+  - type: InstantAction
     event: !type:EventHereticMansusGrasp {}
   - type: HereticAction
     requireMagicItem: false
 
 - type: entity
+  parent: BaseAction
   id: ActionHereticMansusLink
   name: Manse Link
   description: Pierce through reality and connect minds to one another. Default radio key is :z
-  categories: [ HideSpawnMenu ]
   components:
-  - type: EntityTargetAction
+  - type: Action
     useDelay: 10
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Heretic/abilities_heretic.rsi
       state: mansus_link
+  - type: EntityTargetAction
     event: !type:EventHereticMansusLink {}
   - type: HereticAction
     requireMagicItem: false

--- a/Resources/Prototypes/_Goobstation/Heretic/Actions/Heretic/path_ash.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Actions/Heretic/path_ash.yml
@@ -1,100 +1,106 @@
 - type: entity
+  parent: BaseAction
   id: ActionHereticJaunt
   name: Ashen Passage
   description: A short range spell that allows you to pass unimpeded through walls.
-  categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
+  - type: Action
     useDelay: 20
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Heretic/abilities_heretic.rsi
       state: ashen_shift
+  - type: InstantAction
     event: !type:EventHereticAshenShift
   - type: HereticAction
     requireMagicItem: true
     messageLoc: heretic-speech-ash-jaunt
 
 - type: entity
+  parent: BaseAction
   id: ActionHereticBlazingDash
   name: Blazing Dash
   description: A spell that sets you ablaze and temporarily grants you the speed of a wildfire. Be sure to bring a firesuit.
-  categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
+  - type: Action
     useDelay: 10
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Heretic/abilities_heretic.rsi
       state: ashen_shift
+  - type: InstantAction
     event: !type:EventHereticBlazingDash
   - type: HereticAction
     requireMagicItem: true
     messageLoc: heretic-speech-ash-dash
 
 - type: entity
+  parent: BaseAction
   id: ActionHereticVolcanoBlast
   name: Volcanic Blast
   description: Charge up a blast of fire that chains between nearby targets, setting them ablaze.
-  categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
+  - type: Action
     useDelay: 10
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Heretic/abilities_heretic.rsi
       state: volcano_blast
+  - type: InstantAction
     event: !type:EventHereticVolcanoBlast
   - type: HereticAction
     requireMagicItem: true
     messageLoc: heretic-speech-ash-volcano
 
 - type: entity
+  parent: BaseAction
   id: ActionHereticNightwatcherRebirth
   name: Nightwatcher's Rebirth
   description: A spell that extinguishes you and drains nearby heathens engulfed in flames of their life force.
-  categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
+  - type: Action
     useDelay: 15
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Heretic/abilities_heretic.rsi
       state: nightwatcher_rebirth
+  - type: InstantAction
     event: !type:EventHereticNightwatcherRebirth
   - type: HereticAction
     requireMagicItem: true
     messageLoc: heretic-speech-ash-rebirth
 
 - type: entity
+  parent: BaseAction
   id: ActionHereticAscension1
   name: Oath of Flame
   description: For a minute, you will passively create a ring of fire around you.
-  categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
+  - type: Action
     useDelay: 90
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Heretic/abilities_heretic.rsi
       state: ashlord_rite1
+  - type: InstantAction
     event: !type:EventHereticFlames
   - type: HereticAction
     requireMagicItem: true
     messageLoc: heretic-speech-ash-flame
 
 - type: entity
+  parent: BaseAction
   id: ActionHereticAscension2
   name: Fire Cascade
   description: Heats the air around you.
-  categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
+  - type: Action
     useDelay: 30
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Heretic/abilities_heretic.rsi
       state: ashlord_rite2
+  - type: InstantAction
     event: !type:EventHereticCascade
   - type: HereticAction
     requireMagicItem: true

--- a/Resources/Prototypes/_Goobstation/Heretic/Actions/Heretic/path_flesh.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Actions/Heretic/path_flesh.yml
@@ -1,29 +1,34 @@
 - type: entity
+  parent: BaseAction
   id: ActionHereticFleshSurgery
   name: flesh surgery
   description: Remove a random organ from someone, or heal your teammates.
   components:
-  - type: EntityTargetAction
+  - type: Action
     useDelay: 30
-    event: !type:EventHereticFleshSurgery
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Heretic/abilities_heretic.rsi
       state: flesh_surgery
+  - type: TargetAction
+  - type: EntityTargetAction
+    event: !type:EventHereticFleshSurgery
   - type: HereticAction
     messageLoc: heretic-speech-flesh-surgery
 
 - type: entity
+  parent: BaseAction
   id: ActionPolymorphHereticHorror
   name: REALITY UNCOIL
   description: Transform into an eldritch horror.
   components:
-  - type: InstantAction
+  - type: Action
     useDelay: 60
-    event: !type:EventHereticFleshAscend
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Heretic/abilities_heretic.rsi
       state: final_hymn
+  - type: InstantAction
+    event: !type:EventHereticFleshAscend
   - type: HereticAction
     messageLoc: heretic-speech-flesh-worm

--- a/Resources/Prototypes/_Goobstation/Heretic/Actions/Heretic/path_void.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Actions/Heretic/path_void.yml
@@ -1,53 +1,56 @@
 - type: entity
+  parent: BaseAction
   id: ActionHereticVoidBlast
   name: Void Blast
   description: Fire off a cone of ice in front of you.
-  categories: [ HideSpawnMenu ]
   components:
-  - type: WorldTargetAction
+  - type: Action
     useDelay: 15
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Heretic/abilities_heretic.rsi
       state: void_blast
-    event: !type:HereticVoidBlastEvent
-    checkCanAccess: false
+  - type: TargetAction
     range: 0
+  - type: WorldTargetAction
+    event: !type:HereticVoidBlastEvent
   - type: HereticAction
     requireMagicItem: true
     messageLoc: heretic-speech-void-blast
 
 - type: entity
+  parent: BaseAction
   id: ActionHereticVoidPhase
   name: Void Phase
   description: Shift through the void, knocking down everyone around you.
-  categories: [ HideSpawnMenu ]
   components:
-  - type: WorldTargetAction
+  - type: Action
     useDelay: 15
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Heretic/abilities_heretic.rsi
       state: void_phase
-    event: !type:HereticVoidBlinkEvent
-    checkCanAccess: false
+  - type: TargetAction
     range: 0
+  - type: WorldTargetAction
+    event: !type:HereticVoidBlinkEvent
   - type: HereticAction
     requireMagicItem: true
     messageLoc: heretic-speech-void-phase
 
 - type: entity
+  parent: BaseAction
   id: ActionHereticVoidPull
   name: Void Pull
   description: Pull and damage nearby heathens.
-  categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
+  - type: Action
     useDelay: 20
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Heretic/abilities_heretic.rsi
       state: void_pull
+  - type: InstantAction
     event: !type:HereticVoidPullEvent
   - type: HereticAction
     requireMagicItem: true

--- a/Resources/Prototypes/_Impstation/Actions/gastropoid.yml
+++ b/Resources/Prototypes/_Impstation/Actions/gastropoid.yml
@@ -1,9 +1,10 @@
 - type: entity
+  parent: BaseAction
   id: ActionSlime
   name: Slime Trail
   description: Leave a trail of mucin.
   components:
-  - type: InstantAction
+  - type: Action
     icon: Interface/Actions/slime.png
+  - type: InstantAction
     event: !type:SnailSprintActionEvent
-    useDelay: 100

--- a/Resources/Prototypes/_Impstation/Actions/kodepiia.yml
+++ b/Resources/Prototypes/_Impstation/Actions/kodepiia.yml
@@ -1,28 +1,32 @@
 - type: entity
+  parent: BaseAction
   id: ActionKodepiiaScrambler
   name: Scramble Appearance
   description: Change your appearance in a rush. You don't have time to control what comes out!
   components:
-  - type: ConfirmableAction
-    popup: dna-scrambler-action-popup
-  - type: InstantAction
+  - type: Action
     icon:
       sprite: _Goobstation/Changeling/changeling_abilities.rsi
       state: transform
-    event: !type:KodepiiaScramblerEvent
     useDelay: 600
+  - type: ConfirmableAction
+    popup: dna-scrambler-action-popup
+  - type: InstantAction
+    event: !type:KodepiiaScramblerEvent
 
 - type: entity
+  parent: BaseAction
   id: ActionKodepiiaConsume
   name: Consume
   description: Take a bite out of an incapacitated target.
   components:
-  - type: EntityTargetAction
-    event: !type:KodepiiaConsumeEvent
-    useDelay: 120
-    canTargetSelf: false
-    interactOnMiss: false
+  - type: Action
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Changeling/changeling_abilities.rsi
       state: absorb_dna
+    useDelay: 120
+  - type: TargetAction
+  - type: EntityTargetAction
+    event: !type:KodepiiaConsumeEvent
+    canTargetSelf: false

--- a/Resources/Prototypes/_Impstation/Actions/revenant.yml
+++ b/Resources/Prototypes/_Impstation/Actions/revenant.yml
@@ -1,37 +1,45 @@
 - type: entity
+  parent: BaseAction
   id: ActionRevenantHaunt
   name: Haunt
   description: Gives essence and stolen essence for every witness.
   components:
-  - type: InstantAction
+  - type: Action
     itemIconStyle: NoItem
     icon:
       sprite: Mobs/Ghosts/revenant.rsi
       state: icon
-    event: !type:RevenantHauntActionEvent
     useDelay: 20
+  - type: InstantAction
+    event: !type:RevenantHauntActionEvent
+
 
 - type: entity
+  parent: BaseAction
   id: ActionRevenantBloodWriting
   name: Blood Writing
   description: Costs 2 Essence per glyph.
   components:
-    - type: InstantAction
+    - type: Action
       itemIconStyle: NoItem
       icon: Interface/Actions/blood-writing.png
-      event: !type:RevenantBloodWritingEvent
       useDelay: 1
+    - type: InstantAction
+      event: !type:RevenantBloodWritingEvent
 
 - type: entity
+  parent: BaseAction
   id: ActionRevenantAnimate
   name: Animate
   description: Costs 50 Essence.
   components:
-    - type: EntityTargetAction
+    - type: Action
       itemIconStyle: NoItem
       icon: Interface/Actions/animate.png
-      event: !type:RevenantAnimateEvent
       useDelay: 1
+    - type: TargetAction
+    - type: EntityTargetAction
+      event: !type:RevenantAnimateEvent
       canTargetSelf: false
       whitelist:
         components:

--- a/Resources/Prototypes/_Impstation/Actions/spelfs.yml
+++ b/Resources/Prototypes/_Impstation/Actions/spelfs.yml
@@ -1,14 +1,14 @@
 - type: entity
+  parent: BaseMentalAction
   id: ActionViewMoods
   name: View Moods
   description: View your current moods.
   components:
-  - type: InstantAction
+  - type: Action
     itemIconStyle: NoItem
-    checkCanInteract: false
-    checkConsciousness: false
     icon:
       sprite: Interface/Actions/actions_borg.rsi
       state: state-laws
-    event: !type:ToggleMoodsScreenEvent
     useDelay: 0.5
+  - type: InstantAction
+    event: !type:ToggleMoodsScreenEvent

--- a/Resources/Prototypes/_Impstation/Catalog/Fills/Crates/shuttle.yml
+++ b/Resources/Prototypes/_Impstation/Catalog/Fills/Crates/shuttle.yml
@@ -22,7 +22,7 @@
       - id: PortableGeneratorJrPacmanMachineCircuitboard
       - id: JugWeldingFuel
       - id: InflatableDoorStack1
-      
+
 - type: entity
   id: CrateEngineeringAdvancedShittle
   parent: CrateEngineering
@@ -33,7 +33,7 @@
     contents:
       - id: WallmountSubstationElectronics
       - id: WallmountGeneratorAPUElectronics
-      - id: APCElectronics #added apc electronics, capacitor, and empty power cell from the upstream equivelant
-      - id: CapacitorStockPart
+      - id: APCElectronics #added apc electronics, manipulator, and empty power cell from the upstream equivelant
+      - id: MicroManipulatorStockPart
       - id: PowerCellSmallPrinted
 

--- a/Resources/Prototypes/_Impstation/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Clothing/Eyes/hud.yml
@@ -7,17 +7,19 @@
   - type: ShowStaticPriceIcon
 
 - type: entity
+  parent: BaseAction
   id: ActionActivateSalvoHud
   name: Activate S.A.L.V.O hud
   description: Activates the S.A.L.V.O hud, showing the composition of nearby items
   components:
-  - type: InstantAction
+  - type: Action
     useDelay: 10
-    event: !type:ActivateSalvoHudEvent
     sound: !type:SoundPathSpecifier
       path: /Audio/Machines/sonar-ping.ogg
       params:
         volume: -10
+  - type: InstantAction
+    event: !type:ActivateSalvoHudEvent
 
 - type: entity
   parent: [ClothingEyesBase, BaseLensSlot, ShowSalvageIcons]

--- a/Resources/Prototypes/_Impstation/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Clothing/Head/hats.yml
@@ -95,6 +95,7 @@
     node: webberet
 
 #Paramedic Siren Hat
+#TODO fix the light not toggling
 - type: entity
   parent: ClothingHeadBase
   id: ClothingHeadHatParamedicSirenCap
@@ -171,14 +172,14 @@
         name: power-cell-slot-component-slot-name-default
 
 - type: entity
+  parent: BaseToggleAction
   id: ActionToggleParamedicSirenCap
   name: Toggle Paramedic Siren Cap
   description: Toggles the paramedic siren cap on and off.
   components:
-  - type: InstantAction
+  - type: Action
     useDelay: 1
     itemIconStyle: BigItem
-    event: !type:ToggleActionEvent
 
 - type: entity
   parent: ClothingHeadBase

--- a/Resources/Prototypes/_Impstation/Entities/Clothing/Neck/base_clothingneck.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Clothing/Neck/base_clothingneck.yml
@@ -6,11 +6,13 @@
   - type: Neck
 
 - type: entity
+  parent: BaseAction
   id: ActionToggleNeck
   name: Toggle Neck
   description: Something changes...
   components:
-  - type: InstantAction
+  - type: Action
     icon: Interface/Default/blocked.png
     iconOn: { sprite: Clothing/Neck/Misc/headphones.rsi, state: icon-on } # this should probably be somewhere else
+  - type: InstantAction
     event: !type:ToggleNeckEvent

--- a/Resources/Prototypes/_Impstation/Entities/Clothing/Shoes/specific.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Clothing/Shoes/specific.yml
@@ -1,10 +1,13 @@
 - type: entity
+  parent: BaseToggleAction
   id: ActionToggleWaddling
   name: Toggle Waddling
   description: Toggles your mirthful gait.
   components:
-  - type: InstantAction
+  - type: Action
     itemIconStyle: BigItem
+    useDelay: 5
+  - type: InstantAction
     event: !type:ToggleActionEvent
 
 - type: entity

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/Replicators/replicator-actions.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Player/Silicon/Replicators/replicator-actions.yml
@@ -2,21 +2,23 @@
 # all credit for the core gameplay concepts and a lot of the core functionality of the code goes to the folks over at Goob, but I re-wrote enough of it to justify putting it in our filestructure.
 # the original Bingle PR can be found here: https://github.com/Goob-Station/Goob-Station/pull/1519
 - type: entity
+  parent: BaseAction
   id: ActionReplicatorSpawnNest
   name: Manufacture Nest
   description: Create a new nest for your hive.
   components:
-  - type: InstantAction
+  - type: Action
     itemIconStyle: NoItem
     icon: _Impstation/Interface/Actions/spawn_nest.png
-    event: !type:ReplicatorSpawnNestActionEvent
     useDelay: 20
+  - type: InstantAction
+    event: !type:ReplicatorSpawnNestActionEvent
   - type: ConfirmableAction
     popup: replicator-nest-confirm
 
 - type: entity
+  parent: BaseAction
   id: BaseReplicatorLevelupAction
-  categories: [HideSpawnMenu]
   components:
   - type: ConfirmableAction
     popup: replicator-levelup-confirm
@@ -27,12 +29,14 @@
   name: Upgrade (Deconstructor)
   description: Gather nanites. Gain manipulation.
   components:
-  - type: InstantAction
+  - type: Action
     itemIconStyle: NoItem
     icon: _Impstation/Interface/Actions/replicator_level2.png
+    useDelay: 20
+  - type: InstantAction
     event: !type:ReplicatorUpgradeActionEvent
       nextStage: MobReplicatorTier2
-    useDelay: 20
+
 
 - type: entity
   id: ActionReplicatorUpgrade2Alt
@@ -40,12 +44,14 @@
   name: Upgrade (Defender)
   description: Gather nanites. Gain weaponry.
   components:
-  - type: InstantAction
+  - type: Action
     itemIconStyle: NoItem
     icon: _Impstation/Interface/Actions/replicator_level2alt.png
+    useDelay: 20
+  - type: InstantAction
     event: !type:ReplicatorUpgradeActionEvent
       nextStage: MobReplicatorTier2Alt
-    useDelay: 20
+
 
 - type: entity
   id: ActionReplicatorUpgrade3
@@ -53,9 +59,11 @@
   name: Upgrade (Protector)
   description: Gather nanites. Become stronger.
   components:
-  - type: InstantAction
+  - type: Action
     itemIconStyle: NoItem
     icon: _Impstation/Interface/Actions/replicator_level3.png
+    useDelay: 20
+  - type: InstantAction
     event: !type:ReplicatorUpgradeActionEvent
       nextStage: MobReplicatorTier3
-    useDelay: 20
+

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Player/medium.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Player/medium.yml
@@ -1,10 +1,12 @@
 - type: entity
+  parent: BaseAction
   id: ActionToggleGhostsMedium
   name: Toggle Ghosts
   description: Toggle the visibility of ghosts.
   components:
-  - type: InstantAction
+  - type: Action
     icon: { sprite: Mobs/Ghosts/ghost_human.rsi, state: icon }
     clientExclusive: true
     checkCanInteract: false
+  - type: InstantAction
     event: !type:ToggleGhostsMediumActionEvent

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -6,8 +6,7 @@
   - type: MachineBoard
     prototype: MiniGyroscope
     stackRequirements:
-      Manipulator: 1
-      Capacitor: 1
+      Manipulator: 2
       Glass: 2
 
 - type: entity
@@ -21,8 +20,7 @@
     - type: MachineBoard
       prototype: ServiceTechFab
       stackRequirements:
-        MatterBin: 2
-        Manipulator: 2
+        Manipulator: 4
       tagRequirements:
         GlassBeaker:
           amount: 2

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Magic/books.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Magic/books.yml
@@ -1,0 +1,23 @@
+﻿- type: entity
+  id: SpawnSpaceGreaseSpellbook
+  name: space grease spellbook
+  parent: BaseSpellbook
+  components:
+    - type: Sprite
+      sprite: Objects/Misc/books.rsi
+      layers:
+      - state: paper
+      - state: cover_old
+        color: "#ba5a14"
+      - state: decor_wingette_circle
+        color: gold
+      - state: detail_rivets
+        color: gold
+      - state: detail_bookmark
+        color: "#e89b3c"
+      - state: overlay_dirt
+      - state: icon_magic_grease
+        shader: unshaded
+    - type: Spellbook
+      spellActions:
+        ActionSpawnSpaceGreaseSpell: -1

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Tools/drone_tools.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Tools/drone_tools.yml
@@ -161,26 +161,26 @@
 # PAI actions
 
 - type: entity
+  parent: BaseMentalAction
   id: ActionDroneOpenMap
   name: Open Map
   description: Look upon yourself.
   components:
-    - type: InstantAction
-      checkCanInteract: false
-      checkConsciousness: false
-      icon: { sprite: Interface/Actions/pai-map.rsi, state: icon }
-      event: !type:OpenUiActionEvent
-        key: enum.StationMapUiKey.Key
+  - type: Action
+    icon: { sprite: Interface/Actions/pai-map.rsi, state: icon }
+  - type: InstantAction
+    event: !type:OpenUiActionEvent
+      key: enum.StationMapUiKey.Key
 
 - type: entity
+  parent: BaseMentalAction
   id: ActionDronePlayMidi
   name: Play MIDI
   description: Contribute to the ambiance.
   components:
-  - type: InstantAction
-    checkCanInteract: false
-    checkConsciousness: false
+  - type: Action
     icon: Interface/Actions/pai-midi.png
+  - type: InstantAction
     event: !type:OpenUiActionEvent
       key: enum.InstrumentUiKey.Key
 

--- a/Resources/Prototypes/_Impstation/Magic/spawn_spells.yml
+++ b/Resources/Prototypes/_Impstation/Magic/spawn_spells.yml
@@ -1,16 +1,21 @@
 - type: entity
+  parent: BaseAction
   id: ActionSpawnSpaceGreaseSpell
   name: Space Grease
   description: This spell summons a pool of space grease centered on the clicked location.
   components:
-  - type: WorldTargetAction
+  - type: Magic
+  - type: Action
     useDelay: 20
-    range: 30
+    itemIconStyle: BigAction
     sound: !type:SoundPathSpecifier
       path: /Audio/Magic/blink.ogg
     icon:
       sprite: Objects/Magic/magicactions.rsi
       state: space_grease
+  - type: TargetAction
+    range: 30
+  - type: WorldTargetAction
     event: !type:WorldSpawnSpellEvent
       prototypes:
       - id: MagicInstantEffectSpaceGrease

--- a/Resources/Prototypes/_Impstation/Recipes/Construction/Graphs/utilities/wall_recharger.yml
+++ b/Resources/Prototypes/_Impstation/Recipes/Construction/Graphs/utilities/wall_recharger.yml
@@ -54,7 +54,7 @@
     edges:
     - to: electronics
       steps:
-      - material: Capacitor
+      - material: Manipulator
         store: machine_parts
         amount: 2
         doAfter: 1


### PR DESCRIPTION
Should fix yaml linter errors in _Impstation folder from machine part removal and action refactor. I've tested all of them (except heretic ascension actions because I can't figure this shit out) and they mostly all work with some exceptions: 
- The paramedic hat doesn't turn on its light, probably needs to be changed with the changes made to ToggleVisuals. 
- The action from the Medium component doesn't seem to be given to the player when they have enough of the Medium reagent, I assume the system itself probably needs changes with the action rework.

Also moves the grease spellbook to our namespace and fixes the upstream revenant action icons from being tiny.
There also seems to be an issue with the Drozd or it's magazine showing an error texture but my brain is mush right now.