### PR TITLE
entities/objects/weapons upkeep

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -69,17 +69,17 @@
       - id: MagazineBR
         amount: 2
 
-- type: entity
-  parent: ClothingBackpackDuffelSyndicateBundle
-  id: ClothingBackpackDuffelSyndicateFilledRifle
-  name: Estoc DMR bundle
-  description: "For medium-range sharpshooting, the Estoc DMR. Bundled with three magazines."
-  components:
-  - type: StorageFill
-    contents:
-    - id: WeaponRifleEstoc
-    - id: MagazineRifle
-      amount: 2
+# - type: entity #imp #remove unless we think of something that makes this gun more interesting
+#   parent: ClothingBackpackDuffelSyndicateBundle
+#   id: ClothingBackpackDuffelSyndicateFilledRifle
+#   name: Estoc DMR bundle
+#   description: "For medium-range sharpshooting, the Estoc DMR. Bundled with three magazines."
+#   components:
+#   - type: StorageFill
+#     contents:
+#     - id: WeaponRifleEstoc
+#     - id: MagazineRifle
+#       amount: 2
 
 - type: entity
   parent: ClothingBackpackDuffelSyndicateBundle

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -200,19 +200,19 @@
   categories:
   - UplinkWeaponry
 
-- type: listing
-  id: UplinkEstocBundle
-  name: uplink-estoc-bundle-name
-  description: uplink-estoc-bundle-desc
-  icon: { sprite: /Textures/Objects/Weapons/Guns/Rifles/estoc.rsi, state: icon }
-  productEntity: ClothingBackpackDuffelSyndicateFilledRifle
-  discountCategory: veryRareDiscounts
-  discountDownTo:
-    Telecrystal: 11
-  cost:
-    Telecrystal: 18
-  categories:
-  - UplinkWeaponry
+# - type: listing #imp #remove; Basilisk-11 at home
+#   id: UplinkEstocBundle
+#   name: uplink-estoc-bundle-name
+#   description: uplink-estoc-bundle-desc
+#   icon: { sprite: /Textures/Objects/Weapons/Guns/Rifles/estoc.rsi, state: icon }
+#   productEntity: ClothingBackpackDuffelSyndicateFilledRifle
+#   discountCategory: veryRareDiscounts
+#   discountDownTo:
+#     Telecrystal: 11
+#   cost:
+#     Telecrystal: 18
+#   categories:
+#   - UplinkWeaponry
 
 - type: listing
   id: UplinkBulldogBundle

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/caseless_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/caseless_rifle.yml
@@ -125,9 +125,12 @@
     inhandVisuals:
       left:
       - state: inhand-left-mag
+      - state: inhand-left-stripe
+        color: "#820a16" #imp
       right:
       - state: inhand-right-mag
-      # - state: inhand-right-stripe # imp remove
+      - state: inhand-right-stripe
+        color: "#820a16" #imp
 
 - type: entity
   id: MagazinePistolCaselessRiflePractice
@@ -202,7 +205,7 @@
     - state: mag-1
       map: ["enum.GunVisualLayers.Mag"]
     - state: stripe
-      color: "#dbdbdb"
+      color: "#d63b28" #imp
   - type: Item
     inhandVisuals:
       left:
@@ -256,7 +259,7 @@
     - state: mag-1
       map: ["enum.GunVisualLayers.Mag"]
     - state: stripe
-      color: "#dbdbdb"
+      color: "#d63b28" #imp
   - type: Item
     inhandVisuals:
       left:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/light_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/light_rifle.yml
@@ -168,24 +168,24 @@
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeLightRifleIncendiary
-  # - type: Sprite # imp. yeah
-  #   layers:
-  #   - state: base
-  #     map: ["enum.GunVisualLayers.Base"]
-  #   - state: mag-1
-  #     map: ["enum.GunVisualLayers.Mag"]
-  #   - state: stripe
+  - type: Sprite
+    layers:
+    - state: red #imp
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]
+  #   - state: stripe #imp remove
   #     color: "#ff6e52"
-  # - type: Item
-  #   inhandVisuals:
-  #     left:
-  #     - state: inhand-left-mag
-  #     - state: inhand-left-stripe
-  #       color: "#ff6e52"
-  #     right:
-  #     - state: inhand-right-mag
-  #     - state: inhand-right-stripe
-  #       color: "#ff6e52"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left-mag
+      - state: inhand-left-stripe
+        color: "#820a16" #imp
+      right:
+      - state: inhand-right-mag
+      - state: inhand-right-stripe
+        color: "#820a16" #imp
 
 - type: entity
   id: MagazineLightRifleMaxim

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/pistol.yml
@@ -197,24 +197,24 @@
   components:
   - type: BallisticAmmoProvider
     proto: CartridgePistolIncendiary
-  # - type: Sprite # imp lol
-  #   layers:
-  #   - state: base
-  #     map: ["enum.GunVisualLayers.Base"]
-  #   - state: mag-1
-  #     map: ["enum.GunVisualLayers.Mag"]
-  #   - state: stripe
-  #     color: "#ff6e52"
-  # - type: Item
-  #   inhandVisuals:
-  #     left:
-  #     - state: inhand-left-mag
-  #     - state: inhand-left-stripe
-  #       color: "#ff6e52"
-  #     right:
-  #     - state: inhand-right-mag
-  #     - state: inhand-right-stripe
-  #       color: "#ff6e52"
+  - type: Sprite # imp lol
+    layers:
+    - state: red #imp
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]
+    # - state: stripe #imp remove
+    #   color: "#ff6e52"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left-mag
+      - state: inhand-left-stripe
+        color: "#820a16" #imp
+      right:
+      - state: inhand-right-mag
+      - state: inhand-right-stripe
+        color: "#820a16" #imp
 
 - type: entity
   id: MagazinePistolPractice
@@ -332,7 +332,7 @@
     - state: mag-1
       map: ["enum.GunVisualLayers.Mag"]
     - state: stripe
-      color: "#dbdbdb"
+      color: "#d63b28" #imp
   - type: Item
     inhandVisuals:
       left:
@@ -374,7 +374,7 @@
       path: /Audio/Weapons/Guns/MagIn/bullet_insert.ogg
   - type: Sprite
     layers:
-    - state: red # imp remove
+    - state: red #imp
       map: ["enum.GunVisualLayers.Base"]
     - state: mag-1
       map: ["enum.GunVisualLayers.Mag"]
@@ -473,22 +473,22 @@
   components:
   - type: BallisticAmmoProvider
     proto: CartridgePistolIncendiary
-  # - type: Sprite # imp remove
-  #   layers:
-  #   - state: base
-  #     map: ["enum.GunVisualLayers.Base"]
-  #   - state: mag-1
-  #     map: ["enum.GunVisualLayers.Mag"]
-  #   - state: stripe
+  - type: Sprite
+    layers:
+    - state: red #imp
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]
+  #   - state: stripe #imp remove
   #     color: "#ff6e52"
   - type: Item
     inhandVisuals:
       left:
       - state: inhand-left-mag
       - state: inhand-left-stripe
-        color: "#ff6e52"
+        color: "#820a16" #imp
       right:
       - state: inhand-right-mag
       - state: inhand-right-stripe
-        color: "#ff6e52"
+        color: "#820a16"
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/rifle.yml
@@ -87,24 +87,24 @@
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeRifleIncendiary
-  # - type: Sprite # imp
-  #   layers:
-  #   - state: base
-  #     map: ["enum.GunVisualLayers.Base"]
-  #   - state: mag-1
-  #     map: ["enum.GunVisualLayers.Mag"]
-  #   - state: stripe
+  - type: Sprite
+    layers:
+    - state: red #imp
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]
+  #   - state: stripe #imp remove
   #     color: "#ff6e52"
   - type: Item
     inhandVisuals:
       left:
       - state: inhand-left-mag
       - state: inhand-left-stripe
-        color: "#ff6e52"
+        color: "#820a16" #imp
       right:
       - state: inhand-right-mag
       - state: inhand-right-stripe
-        color: "#ff6e52"
+        color: "#820a16" #imp
 
 - type: entity
   id: MagazineRiflePractice

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/SpeedLoaders/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/SpeedLoaders/magnum.yml
@@ -58,7 +58,7 @@
   - type: BallisticAmmoProvider
     proto: null
   - type: Sprite
-    sprite: Objects/Weapons/Guns/Ammunition/SpeedLoaders/Magnum/magnum_speed_loader.rsi
+    sprite: _Impstation/Objects/Weapons/Guns/Ammunition/SpeedLoaders/Magnum/magnum_speed_loader.rsi #imp
     layers:
       - state: base
         map: [ "enum.GunVisualLayers.Base" ]
@@ -93,7 +93,7 @@
   - type: BallisticAmmoProvider
     proto: CartridgeMagnumPractice
   - type: Sprite
-    sprite: Objects/Weapons/Guns/Ammunition/SpeedLoaders/Magnum/magnum_speed_loader.rsi
+    sprite: _Impstation/Objects/Weapons/Guns/Ammunition/SpeedLoaders/Magnum/magnum_speed_loader.rsi #imp
     layers:
       - state: base
         map: [ "enum.GunVisualLayers.Base" ]
@@ -110,12 +110,12 @@
       - state: inhand-left-mag
       - state: inhand-left-ammo
       - state: inhand-left-stripe
-        color: "#ea5800"
+        color: "#d63b28" #imp
       right:
       - state: inhand-right-mag
       - state: inhand-right-ammo
       - state: inhand-right-stripe
-        color: "#ea5800"
+        color: "#d63b28" #imp
 
 - type: entity
   id: SpeedLoaderMagnumAP
@@ -126,7 +126,7 @@
   - type: BallisticAmmoProvider
     proto: CartridgeMagnumAP
   - type: Sprite
-    sprite: Objects/Weapons/Guns/Ammunition/SpeedLoaders/Magnum/magnum_speed_loader.rsi
+    sprite: _Impstation/Objects/Weapons/Guns/Ammunition/SpeedLoaders/Magnum/magnum_speed_loader.rsi #imp
     layers:
       - state: base
         map: [ "enum.GunVisualLayers.Base" ]
@@ -159,7 +159,7 @@
   - type: BallisticAmmoProvider
     proto: CartridgeMagnumUranium
   - type: Sprite
-    sprite: Objects/Weapons/Guns/Ammunition/SpeedLoaders/Magnum/magnum_speed_loader.rsi
+    sprite: _Impstation/Objects/Weapons/Guns/Ammunition/SpeedLoaders/Magnum/magnum_speed_loader.rsi #imp
     layers:
       - state: base
         map: [ "enum.GunVisualLayers.Base" ]
@@ -176,9 +176,9 @@
       - state: inhand-left-mag
       - state: inhand-left-ammo
       - state: inhand-left-stripe
-        color: "#00cd42"
+        color: "#6b805e" #imp
       right:
       - state: inhand-right-mag
       - state: inhand-right-ammo
       - state: inhand-right-stripe
-        color: "#00cd42"
+        color: "#6b805e" #imp

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -237,70 +237,70 @@
     zeroVisible: true
   - type: Appearance
 
-- type: entity
-  name: Estoc DMR
-  parent: [BaseWeaponRifle, BaseSyndicateContraband]
-  id: WeaponRifleEstoc
-  description: A designated marksman rifle, favored for medium-to-long range engagements. Uses .20 rifle ammo.
-  components:
-  - type: Sprite
-    sprite: Objects/Weapons/Guns/Rifles/estoc.rsi
-    layers:
-    - state: base
-      map: ["enum.GunVisualLayers.Base"]
-    - state: mag-0
-      map: ["enum.GunVisualLayers.Mag"]
-  - type: Clothing
-    sprite: Objects/Weapons/Guns/Rifles/estoc.rsi
-  - type: Gun
-    soundGunshot:
-      path: /Audio/Weapons/Guns/Gunshots/estocshot.ogg
-    minAngle: 30
-    maxAngle: 43
-    shotsPerBurst: 3
-    selectedMode: Burst
-    availableModes:
-    - Burst
-    - SemiAuto
-    burstFireRate: 14
-  - type: GunWieldBonus
-    minAngle: -28
-    maxAngle: -25
-  - type: ItemSlots
-    slots:
-      gun_magazine:
-        name: Magazine
-        startingItem: MagazineRifle
-        insertSound: /Audio/Weapons/Guns/MagIn/ltrifle_magin.ogg
-        ejectSound: /Audio/Weapons/Guns/MagOut/ltrifle_magout.ogg
-        priority: 2
-        whitelist:
-          tags:
-          - MagazineRifle
-        whitelistFailPopup: gun-magazine-whitelist-fail
-      gun_chamber:
-        name: Chamber
-        startingItem: CartridgeRifle
-        priority: 1
-        whitelist:
-          tags:
-          - CartridgeRifle
-  - type: SpeedModifiedOnWield
-    walkModifier: 0.75
-    sprintModifier: 0.75
-  - type: CursorOffsetRequiresWield
-  - type: EyeCursorOffset
-    maxOffset: 2
-    pvsIncrease: 0.2
-  - type: ContainerContainer
-    containers:
-      gun_magazine: !type:ContainerSlot
-      gun_chamber: !type:ContainerSlot
-  - type: MagazineVisuals
-    magState: mag
-    steps: 1
-    zeroVisible: true
-  - type: Appearance
+# - type: entity #imp #removed because it's way too similar to something we already have and I don't want a wizard spawning this unless I'm respriting it, which I don't want to do if it's just a redundant gun.
+#   name: Estoc DMR
+#   parent: [BaseWeaponRifle, BaseSyndicateContraband]
+#   id: WeaponRifleEstoc
+#   description: A designated marksman rifle, favored for medium-to-long range engagements. Uses .20 rifle ammo.
+#   components:
+#   - type: Sprite
+#     sprite: Objects/Weapons/Guns/Rifles/estoc.rsi
+#     layers:
+#     - state: base
+#       map: ["enum.GunVisualLayers.Base"]
+#     - state: mag-0
+#       map: ["enum.GunVisualLayers.Mag"]
+#   - type: Clothing
+#     sprite: Objects/Weapons/Guns/Rifles/estoc.rsi
+#   - type: Gun
+#     soundGunshot:
+#       path: /Audio/Weapons/Guns/Gunshots/estocshot.ogg
+#     minAngle: 30
+#     maxAngle: 43
+#     shotsPerBurst: 3
+#     selectedMode: Burst
+#     availableModes:
+#     - Burst
+#     - SemiAuto
+#     burstFireRate: 14
+#   - type: GunWieldBonus
+#     minAngle: -28
+#     maxAngle: -25
+#   - type: ItemSlots
+#     slots:
+#       gun_magazine:
+#         name: Magazine
+#         startingItem: MagazineRifle
+#         insertSound: /Audio/Weapons/Guns/MagIn/ltrifle_magin.ogg
+#         ejectSound: /Audio/Weapons/Guns/MagOut/ltrifle_magout.ogg
+#         priority: 2
+#         whitelist:
+#           tags:
+#           - MagazineRifle
+#         whitelistFailPopup: gun-magazine-whitelist-fail
+#       gun_chamber:
+#         name: Chamber
+#         startingItem: CartridgeRifle
+#         priority: 1
+#         whitelist:
+#           tags:
+#           - CartridgeRifle
+#   - type: SpeedModifiedOnWield
+#     walkModifier: 0.75
+#     sprintModifier: 0.75
+#   - type: CursorOffsetRequiresWield
+#   - type: EyeCursorOffset
+#     maxOffset: 2
+#     pvsIncrease: 0.2
+#   - type: ContainerContainer
+#     containers:
+#       gun_magazine: !type:ContainerSlot
+#       gun_chamber: !type:ContainerSlot
+#   - type: MagazineVisuals
+#     magState: mag
+#     steps: 1
+#     zeroVisible: true
+#   - type: Appearance
 
 - type: entity
   name: Foam Force Astro Ace


### PR DESCRIPTION
- Commented out the Estoc. Decided its current iteration is far too similar, but less interesting, than the Basilisk-11. If we really care about the scope feature I can honestly just add that to the Basilisk. Commented it out completely because I personally want to limit as many instances of random upstream guns I haven't resprited suddenly appearing in weird places like Wizard spawns. If we care about that I can put the work into spruce it up and un-comment it in another PR.

- Updated the magazine.yml's to correctly use our sprites. The stripe colour change technology is fine for in-hands because it's affecting all of 3-4 pixels, but larger sprites such as the icons this tech really shows its downside because it doesn't support hue-shifting or specific palettes, and is going to stand out and look worse when it's more pixels with more shades involved.

- Corrected some colour assignments and reverted the speedloader to use our assets. At the moment livefire uses the same colour as incendiary, as has been the case for a while now, but in another PR I can re-assign a new colour for standard live-fire.